### PR TITLE
Avoid checking long strings for matching against whitespace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,9 +410,9 @@ impl Repr {
 
 #[cfg(feature = "serde")]
 mod serde {
+    use super::SmolStr;
     use ::serde::de::{Deserializer, Error, Unexpected, Visitor};
     use std::fmt;
-    use super::SmolStr;
 
     // https://github.com/serde-rs/serde/blob/629802f2abfd1a54a6072992888fea7ca5bc209f/serde/src/private/de.rs#L56-L125
     fn smol_str<'de: 'a, 'a, D>(deserializer: D) -> Result<SmolStr, D::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
-use std::{borrow::Borrow, cmp::Ordering, fmt, hash, iter, ops::Deref, sync::Arc};
+use std::{
+    borrow::Borrow,
+    cmp::{self, Ordering},
+    fmt, hash, iter,
+    ops::Deref,
+    sync::Arc,
+};
 
 /// A `SmolStr` is a string type that has the following properties:
 ///
@@ -358,10 +364,17 @@ impl Repr {
                 };
             }
 
-            let newlines = text.bytes().take_while(|&b| b == b'\n').count();
-            if text[newlines..].bytes().all(|b| b == b' ') {
-                let spaces = len - newlines;
-                if newlines <= N_NEWLINES && spaces <= N_SPACES {
+            if len <= N_NEWLINES + N_SPACES {
+                let bytes = text.as_bytes();
+                let possible_newline_count = cmp::min(len, N_NEWLINES);
+                let newlines = bytes[..possible_newline_count]
+                    .iter()
+                    .take_while(|&&b| b == b'\n')
+                    .count();
+                let possible_space_count = len - newlines;
+                if possible_space_count <= N_SPACES && bytes[newlines..].iter().all(|&b| b == b' ')
+                {
+                    let spaces = possible_space_count;
                     return Repr::Substring { newlines, spaces };
                 }
             }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -87,7 +87,7 @@ proptest! {
 #[cfg(feature = "serde")]
 mod serde_tests {
     use super::*;
-    use serde::{Serialize, Deserialize};
+    use serde::{Deserialize, Serialize};
     use std::collections::HashMap;
 
     #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
Previously, the string was checked for starting with newlines and ending with spaces, then ensuring that the length of those substrings were short enough to use our constant. Instead, only do the check for as many items as we have in the WS constant.

In the worst case, this avoids an O(n) check if the input is a long string of `\n`, possibly followed by a long string of spaces.
