### PR TITLE
Update CI badge in readme to point to Github Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # smol_str
 
-[![Build Status](https://travis-ci.org/matklad/smol_str.svg?branch=master)](https://travis-ci.org/matklad/smol_str)
+[![CI](https://github.com/rust-analyzer/smol_str/workflows/CI/badge.svg)](https://github.com/rust-analyzer/smol_str/actions?query=branch%3Amaster+workflow%3ACI)
 [![Crates.io](https://img.shields.io/crates/v/smol_str.svg)](https://crates.io/crates/smol_str)
 [![API reference](https://docs.rs/smol_str/badge.svg)](https://docs.rs/smol_str/)
 


### PR DESCRIPTION
The Travis workflow was deleted in 1150aa92ab1fa6ba489f603f1969fb7f37d1ac8d