### PR TITLE
Add cargo feature for using `Rc` instead of `Arc` (#30)

### DIFF
--- a/.github/ci.rs
+++ b/.github/ci.rs
@@ -34,8 +34,18 @@ fn try_main() -> Result<()> {
     }
 
     {
+        let _s = Section::new("BUILD_ONLY_DEFAULT_FEATURES");
+        shell("cargo test --workspace --no-run")?;
+    }
+
+    {
         let _s = Section::new("TEST");
         shell("cargo test --all-features --workspace")?;
+    }
+
+    {
+        let _s = Section::new("TEST_ONLY_DEFAULT_FEATURES");
+        shell("cargo test --workspace")?;
     }
 
     let current_branch = shell_output("git branch --show-current")?;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ serde =  { version = "1", features = [ "derive" ] }
 
 [features]
 default = ["std"]
+nosync = []
 std = ["serde/std"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ languages. Strings consisting of a series of newlines, followed by a series of
 whitespace are a typical pattern in computer programs because of indentation.
 Note that a specialized interner might be a better solution for some use cases.
 
+## Cargo features
+
+- `std` (on by default): use the Rust standard library.
+    Disable for `no_std` mode.
+
+- `derive`: implement Serde traits for `SmolStr`.
+
+- `nosync`: use `Rc` internally instead of `Arc`. This makes the `SmolStr` type 
+    more performant in single-threaded contexts, but it will not be `Send` or `Sync`.
+
 ## MSRV Policy
 
 Minimal Supported Rust Version: latest stable.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,19 @@ use std::{
 };
 
 #[cfg(not(feature = "std"))]
-use alloc::{
-    string::{String, ToString},
-    sync::Arc,
-};
+use alloc::string::{String, ToString};
 
-#[cfg(feature = "std")]
+#[cfg(all(not(feature = "std"), not(feature = "nosync")))]
+use alloc::sync::Arc;
+
+#[cfg(all(not(feature = "std"), feature = "nosync"))]
+use alloc::sync::Rc as Arc;
+
+#[cfg(all(feature = "std", not(feature = "nosync")))]
 use std::sync::Arc;
+
+#[cfg(all(feature = "std", feature = "nosync"))]
+use std::rc::Rc as Arc;
 
 /// A `SmolStr` is a string type that has the following properties:
 ///

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -21,7 +21,7 @@ fn assert_traits() {
 #[cfg(all(feature = "std", feature = "nosync"))]
 #[test]
 fn assert_traits() {
-    fn f<T: Send + ::std::fmt::Debug + Clone>() {}
+    fn f<T: ::std::fmt::Debug + Clone>() {}
     f::<SmolStr>();
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,9 +11,17 @@ fn smol_str_is_smol() {
     );
 }
 
+#[cfg(all(feature = "std", not(feature = "nosync")))]
 #[test]
 fn assert_traits() {
     fn f<T: Send + Sync + ::std::fmt::Debug + Clone>() {}
+    f::<SmolStr>();
+}
+
+#[cfg(all(feature = "std", feature = "nosync"))]
+#[test]
+fn assert_traits() {
+    fn f<T: Send + ::std::fmt::Debug + Clone>() {}
     f::<SmolStr>();
 }
 


### PR DESCRIPTION
If a crate uses `SmolStr` only in a single-threaded context, using `Rc` is more performant than `Arc`. This PR adds a new cargo feature `nosync` which is off by default. When the feature is enabled, `Rc` is used internally instead of `Arc`. Because `Rc` and `Arc` have the same API, this is just a matter of doing some conditional compilation on the imports.

An issue was already filed for this (#30). Separate to this issue, I'm working on a language parser/executor for the TeX language, which necessarily must be single-threaded and I'm hoping to use `SmolStr` in the project. I have a performance benchmark for the project which I can run for `Rc` versus `Arc` to quantify the performance change here.