### PR TITLE
Add const generic size for inlined storage

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,6 @@
 use proptest::{prop_assert, prop_assert_eq, proptest};
 
-use smol_str::SmolStr;
+use smol_str::{SmolStr, SmolStrN};
 
 #[test]
 #[cfg(target_pointer_width = "64")]
@@ -9,6 +9,16 @@ fn smol_str_is_smol() {
         ::std::mem::size_of::<SmolStr>(),
         ::std::mem::size_of::<String>(),
     );
+}
+
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn smoln_str_is_smol() {
+    assert_eq!(::std::mem::size_of::<SmolStrN<8>>(), 24);
+    assert_eq!(::std::mem::size_of::<SmolStrN<16>>(), 24);
+    assert_eq!(::std::mem::size_of::<SmolStrN<32>>(), 40);
+    assert_eq!(::std::mem::size_of::<SmolStrN<64>>(), 72);
+    assert_eq!(::std::mem::size_of::<SmolStrN<128>>(), 136);
 }
 
 #[test]
@@ -51,11 +61,26 @@ fn old_const_fn_ctor() {
     assert_eq!(LONG, SmolStr::from("ABCDEFGHIZKLMNOPQRSTUV"));
 }
 
-fn check_props(std_str: &str, smol: SmolStr) -> Result<(), proptest::test_runner::TestCaseError> {
+macro_rules! check_props {
+    ($input: expr) => {{
+        check_props!($input, 22)
+    }};
+    ($input: expr, $n: literal) => {{
+        let std_str = $input.as_str();
+        let smol = SmolStrN::<$n>::new($input.clone());
+
+        check_props(std_str, smol)?;
+    }};
+}
+
+fn check_props<const N: usize>(
+    std_str: &str,
+    smol: SmolStrN<N>,
+) -> Result<(), proptest::test_runner::TestCaseError> {
     prop_assert_eq!(smol.as_str(), std_str);
     prop_assert_eq!(smol.len(), std_str.len());
     prop_assert_eq!(smol.is_empty(), std_str.is_empty());
-    if smol.len() <= 22 {
+    if smol.len() <= N {
         prop_assert!(!smol.is_heap_allocated());
     }
     Ok(())
@@ -64,36 +89,54 @@ fn check_props(std_str: &str, smol: SmolStr) -> Result<(), proptest::test_runner
 proptest! {
     #[test]
     fn roundtrip(s: String) {
-        check_props(s.as_str(), SmolStr::new(s.clone()))?;
+        check_props!(s);
+        check_props!(s, 32);
     }
 
     #[test]
     fn roundtrip_spaces(s in r"( )*") {
-        check_props(s.as_str(), SmolStr::new(s.clone()))?;
+        check_props!(s);
+        check_props!(s, 32);
     }
 
     #[test]
     fn roundtrip_newlines(s in r"\n*") {
-        check_props(s.as_str(), SmolStr::new(s.clone()))?;
+        check_props!(s);
+        check_props!(s, 32);
     }
 
     #[test]
     fn roundtrip_ws(s in r"( |\n)*") {
-        check_props(s.as_str(), SmolStr::new(s.clone()))?;
+        check_props!(s);
+        check_props!(s, 32);
     }
 
     #[test]
     fn from_string_iter(slices in proptest::collection::vec(".*", 1..100)) {
-        let string: String = slices.iter().map(|x| x.as_str()).collect();
-        let smol: SmolStr = slices.into_iter().collect();
-        check_props(string.as_str(), smol)?;
+        {
+            let string: String = slices.iter().map(|x| x.as_str()).collect();
+            let smol = slices.clone().into_iter().collect();
+            check_props::<22>(string.as_str(), smol)?;
+        }
+        {
+            let string: String = slices.iter().map(|x| x.as_str()).collect();
+            let smol = slices.into_iter().collect();
+            check_props::<32>(string.as_str(), smol)?;
+        }
     }
 
     #[test]
     fn from_str_iter(slices in proptest::collection::vec(".*", 1..100)) {
-        let string: String = slices.iter().map(|x| x.as_str()).collect();
-        let smol: SmolStr = slices.iter().collect();
-        check_props(string.as_str(), smol)?;
+        {
+            let string: String = slices.iter().map(|x| x.as_str()).collect();
+            let smol = slices.iter().collect();
+            check_props::<22>(string.as_str(), smol)?;
+        }
+        {
+            let string: String = slices.iter().map(|x| x.as_str()).collect();
+            let smol = slices.iter().collect();
+            check_props::<32>(string.as_str(), smol)?;
+        }
     }
 }
 
@@ -106,6 +149,7 @@ mod serde_tests {
     #[derive(Serialize, Deserialize)]
     struct SmolStrStruct {
         pub(crate) s: SmolStr,
+        pub(crate) sn: SmolStrN<50>,
         pub(crate) vec: Vec<SmolStr>,
         pub(crate) map: HashMap<SmolStr, SmolStr>,
     }
@@ -134,6 +178,7 @@ mod serde_tests {
         map.insert(SmolStr::new("a"), SmolStr::new("ohno"));
         let struct_ = SmolStrStruct {
             s: SmolStr::new("Hello, World"),
+            sn: SmolStrN::new("Hello, World 50"),
             vec: vec![SmolStr::new("Hello, World"), SmolStr::new("Hello, World")],
             map,
         };
@@ -147,6 +192,7 @@ mod serde_tests {
         map.insert(SmolStr::new("a"), SmolStr::new("ohno"));
         let struct_ = SmolStrStruct {
             s: SmolStr::new("Hello, World"),
+            sn: SmolStrN::new("Hello, World 50"),
             vec: vec![SmolStr::new("Hello, World"), SmolStr::new("Hello, World")],
             map,
         };
@@ -197,22 +243,24 @@ fn test_search_in_hashmap() {
 fn test_from_char_iterator() {
     let examples = [
         // Simple keyword-like strings
-        ("if", false),
-        ("for", false),
-        ("impl", false),
+        ("if", false, false),
+        ("for", false, false),
+        ("impl", false, false),
         // Strings containing two-byte characters
-        ("パーティーへ行かないか", true),
-        ("パーティーへ行か", true),
-        ("パーティーへ行_", false),
-        ("和製漢語", false),
-        ("部落格", false),
-        ("사회과학원 어학연구소", true),
+        ("パーティーへ行かないか", true, false),
+        ("パーティーへ行か", true, false),
+        ("パーティーへ行_", false, false),
+        ("和製漢語", false, false),
+        ("部落格", false, false),
+        ("사회과학원 어학연구소", true, false),
         // String containing diverse characters
-        ("表ポあA鷗ŒéＢ逍Üßªąñ丂㐀𠀀", true),
+        ("表ポあA鷗ŒéＢ逍Üßªąñ丂㐀𠀀", true, true),
     ];
-    for (raw, is_heap) in &examples {
+    for (raw, is_heap, is_heap_when_n_42) in &examples {
         let s: SmolStr = raw.chars().collect();
         assert_eq!(s.as_str(), *raw);
         assert_eq!(s.is_heap_allocated(), *is_heap);
+        let s: SmolStrN<42> = raw.chars().collect();
+        assert_eq!(s.is_heap_allocated(), *is_heap_when_n_42);
     }
 }


### PR DESCRIPTION
This makes it possible to control the maximum length (in bytes) of inlined strings.

Type alias is provided to keep the old type name behaving as previously.