### PR TITLE
feat: impl `AsRef<OsStr>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
 use alloc::{
@@ -307,6 +307,13 @@ impl From<SmolStr> for String {
 impl Borrow<str> for SmolStr {
     fn borrow(&self) -> &str {
         self.as_str()
+    }
+}
+
+#[cfg(feature = "std")]
+impl AsRef<std::ffi::OsStr> for SmolStr {
+    fn as_ref(&self) -> &std::ffi::OsStr {
+        (&**self).as_ref()
     }
 }
 


### PR DESCRIPTION
There are cases in `std` where functions expect a `T: AsRef<OsStr>` when working with OS-related operations like getting env vars through `std::env::var`.

This may be too niche to be worth adding, and is not necessarily related to the original purpose of "programming language tokens", so feel free to close!