### PR TITLE
Add Writer and ToSmolStr

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -258,3 +258,15 @@ fn test_bad_size_hint_char_iter() {
     assert!(!new.is_heap_allocated());
     assert_eq!(new, collected);
 }
+
+#[test]
+fn test_to_smolstr() {
+    use smol_str::ToSmolStr;
+
+    for i in 0..26 {
+        let a = &"abcdefghijklmnopqrstuvwxyz"[i..];
+
+        assert_eq!(a, a.to_smolstr());
+        assert_eq!(a, smol_str::format_smolstr!("{}", a));
+    }
+}


### PR DESCRIPTION
Provides a `fmt::Write` Writer that will try not to allocate immediately, a trait similar to `ToString` that makes use of the Writer, and a macro `format_smolstr!()` that is similar to `format!()`. 

Cannot use specialization with `ToSmolStr`, sadly, as `ToString` does.