### PR TITLE
Use optional dependency feature syntax to make serde actually optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smol_str"
-version = "0.1.24"
+version = "0.1.25"
 description = "small-string optimized string type with O(1) clone"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-analyzer/smol_str"
@@ -18,4 +18,4 @@ serde = { version = "1.0.136", features = ["derive"] }
 
 [features]
 default = ["std"]
-std = ["serde/std"]
+std = ["serde?/std"]


### PR DESCRIPTION
Revives https://github.com/rust-analyzer/smol_str/pull/46
It has been long enough that this shouldn't break too many people anymore