### PR TITLE
Implementing `From<Arc<str>> for SmolStr` and `From<SmolStr> for Arc<str>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,8 @@ impl From<Box<str>> for SmolStr {
 impl From<Arc<str>> for SmolStr {
     #[inline]
     fn from(s: Arc<str>) -> SmolStr {
-        SmolStr(Repr::Heap(s))
+        let repr = Repr::new_on_stack(s.as_ref()).unwrap_or_else(|| Repr::Heap(s));
+        Self(repr)
     }
 }
 
@@ -438,40 +439,45 @@ enum Repr {
 }
 
 impl Repr {
+    /// This function tries to create a new Repr::Inline or Repr::Substring
+    /// If it isn't possible, this function returns None
+    fn new_on_stack<T>(text: T) -> Option<Self>
+    where
+        T: AsRef<str>,
+    {
+        let text = text.as_ref();
+
+        let len = text.len();
+        if len <= INLINE_CAP {
+            let mut buf = [0; INLINE_CAP];
+            buf[..len].copy_from_slice(text.as_bytes());
+            return Some(Repr::Inline {
+                len: unsafe { transmute(len as u8) },
+                buf,
+            });
+        }
+
+        if len <= N_NEWLINES + N_SPACES {
+            let bytes = text.as_bytes();
+            let possible_newline_count = cmp::min(len, N_NEWLINES);
+            let newlines = bytes[..possible_newline_count]
+                .iter()
+                .take_while(|&&b| b == b'\n')
+                .count();
+            let possible_space_count = len - newlines;
+            if possible_space_count <= N_SPACES && bytes[newlines..].iter().all(|&b| b == b' ') {
+                let spaces = possible_space_count;
+                return Some(Repr::Substring { newlines, spaces });
+            }
+        }
+        None
+    }
+
     fn new<T>(text: T) -> Self
     where
         T: AsRef<str>,
     {
-        {
-            let text = text.as_ref();
-
-            let len = text.len();
-            if len <= INLINE_CAP {
-                let mut buf = [0; INLINE_CAP];
-                buf[..len].copy_from_slice(text.as_bytes());
-                return Repr::Inline {
-                    len: unsafe { transmute(len as u8) },
-                    buf,
-                };
-            }
-
-            if len <= N_NEWLINES + N_SPACES {
-                let bytes = text.as_bytes();
-                let possible_newline_count = cmp::min(len, N_NEWLINES);
-                let newlines = bytes[..possible_newline_count]
-                    .iter()
-                    .take_while(|&&b| b == b'\n')
-                    .count();
-                let possible_space_count = len - newlines;
-                if possible_space_count <= N_SPACES && bytes[newlines..].iter().all(|&b| b == b' ')
-                {
-                    let spaces = possible_space_count;
-                    return Repr::Substring { newlines, spaces };
-                }
-            }
-        }
-
-        Repr::Heap(text.as_ref().into())
+        Self::new_on_stack(text.as_ref()).unwrap_or_else(|| Repr::Heap(text.as_ref().into()))
     }
 
     #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,10 +334,27 @@ impl From<Box<str>> for SmolStr {
     }
 }
 
+impl From<Arc<str>> for SmolStr {
+    #[inline]
+    fn from(s: Arc<str>) -> SmolStr {
+        SmolStr(Repr::Heap(s))
+    }
+}
+
 impl<'a> From<Cow<'a, str>> for SmolStr {
     #[inline]
     fn from(s: Cow<'a, str>) -> SmolStr {
         SmolStr::new(s)
+    }
+}
+
+impl From<SmolStr> for Arc<str> {
+    #[inline(always)]
+    fn from(text: SmolStr) -> Self {
+        match text.0 {
+            Repr::Heap(data) => data,
+            _ => text.as_str().into(),
+        }
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use proptest::{prop_assert, prop_assert_eq, proptest};
 
 use smol_str::SmolStr;
@@ -21,7 +23,11 @@ fn assert_traits() {
 fn conversions() {
     let s: SmolStr = "Hello, World!".into();
     let s: String = s.into();
-    assert_eq!(s, "Hello, World!")
+    assert_eq!(s, "Hello, World!");
+
+    let s: SmolStr = Arc::<str>::from("Hello, World!").into();
+    let s: Arc<str> = s.into();
+    assert_eq!(s.as_ref(), "Hello, World!");
 }
 
 #[test]


### PR DESCRIPTION
Solves #57 

- Adding implementations to convert `SmolStr` to and from `Arc<str>`
- Also adding one test to verify

---

The `From<SmolStr>` implementation is good. It saves an alloc in the `Repr::Heap` case, and allocates in the stack cases. It should be good to go.

The `From<Arc<str>>` does currently does not check for inline-able or whitespace strings. All `Arc<str>` become `Repr::Heap`. If this is a problem, could I get some feedback on how to solve it? Currently only `SmolStr::new` contains the code to detect inlines and whitespaces, so there are two options

- I could duplicate this whole code block into the `From` impl
- Or I could split it off into a separate function like `fn new_on_stack(text: &str) -> Option<SmolStr>` and then use that in `Smol::new` and `From<Arc<str>>`

