### PR TITLE
docs: fix missing codeblock backtick

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use core::{
 
 /// A `SmolStr` is a string type that has the following properties:
 ///
-/// * `size_of::<SmolStr>() == 24 (therefor == size_of::<String>() on 64 bit platforms)
+/// * `size_of::<SmolStr>() == 24` (therefor `== size_of::<String>()` on 64 bit platforms)
 /// * `Clone` is `O(1)`
 /// * Strings are stack-allocated if they are:
 ///     * Up to 23 bytes long


### PR DESCRIPTION
The size comparison was missing the backticks needed in order to format it as inline codeblock, which caused it to display like this:

> `size_of::() == 24 (therefor == size_of::() on 64 bit platforms)

However, with this PR it'll be displayed like this:

> `size_of::<SmolStr>() == 24` (therefor `== size_of::<String>()` on 64 bit platforms)
