### PR TITLE
Manually implement Clone 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use core::{
 /// `WS`: A string of 32 newlines followed by 128 spaces.
 pub struct SmolStr(Repr);
 
-impl Clone for SmolStr{
+impl Clone for SmolStr {
     #[inline]
     fn clone(&self) -> Self {
         if !self.is_heap_allocated() {
@@ -43,7 +43,6 @@ impl Clone for SmolStr{
 }
 
 impl SmolStr {
-    
     #[deprecated = "Use `new_inline` instead"]
     pub const fn new_inline_from_ascii(len: usize, bytes: &[u8]) -> SmolStr {
         assert!(len <= INLINE_CAP);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(core_intrinsics, test)]
 #![no_std]
 extern crate alloc;
 
@@ -33,7 +34,63 @@ use core::{
 #[derive(Clone)]
 pub struct SmolStr(Repr);
 
+mod bench {
+    extern crate test;
+    use test::Bencher;
+    fn test_strings() -> [crate::SmolStr; 200] {
+        [0; 200].map(|_| crate::SmolStr::new("0123456780"))
+    }
+    #[bench]
+    fn bench_derive_clone(b: &mut Bencher) {
+        let it = test::black_box(test_strings());
+        b.iter(|| {
+            (0..1000)
+                .map(|_| it.iter().map(|e| e.clone()))
+                .flatten()
+                .filter(|o| o.is_heap_allocated())
+                .count()
+        })
+    }
+    #[bench]
+    fn bench_new_clone(b: &mut Bencher) {
+        let it = test::black_box(test_strings());
+        b.iter(|| {
+            (0..1000)
+                .map(|_| it.iter().map(|e| e.new_clone()))
+                .flatten()
+                .filter(|o| o.is_heap_allocated())
+                .count()
+        })
+    }
+    #[bench]
+    fn bench_match_clone(b: &mut Bencher) {
+        let it = test::black_box(test_strings());
+        b.iter(|| {
+            (0..1000)
+                .map(|_| it.iter().map(|e| e.match_clone()))
+                .flatten()
+                .filter(|o| o.is_heap_allocated())
+                .count()
+        })
+    }
+}
+
 impl SmolStr {
+    
+    #[inline(always)]
+    pub fn new_clone(&self) -> Self {
+        if !self.is_heap_allocated() {
+            return unsafe { core::mem::transmute_copy(self) };
+        }
+        Self(self.0.clone())
+    }
+    #[inline(always)]
+    pub fn match_clone(&self) -> Self {
+        match &self.0 {
+            Repr::Heap(h) => return Self(Repr::Heap(h.clone())),
+            _ => unsafe { core::mem::transmute_copy(self) },
+        }
+    }
     #[deprecated = "Use `new_inline` instead"]
     pub const fn new_inline_from_ascii(len: usize, bytes: &[u8]) -> SmolStr {
         assert!(len <= INLINE_CAP);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(core_intrinsics, test)]
 #![no_std]
 extern crate alloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,12 +503,12 @@ enum InlineSize {
 
 #[derive(Clone, Debug)]
 enum Repr {
-    Heap(Arc<str>),
-    Static(&'static str),
     Inline {
         len: InlineSize,
         buf: [u8; INLINE_CAP],
     },
+    Static(&'static str),
+    Heap(Arc<str>),
 }
 
 impl Repr {


### PR DESCRIPTION
I noticed clone was producing inefficient assembly. 
Here is a PR that manually implements Clone.  

The first commit has benchmarks comparing three methods.

Here are my results:

Cloning inline strings:

```
running 3 tests
test bench::bench_derive_clone ... bench:     460,725 ns/iter (+/- 9,990)
test bench::bench_match_clone  ... bench:     177,981 ns/iter (+/- 13,023)
test bench::bench_new_clone    ... bench:     178,105 ns/iter (+/- 4,005)
```

Cloning heap strings: 

```
running 3 tests
test bench::bench_derive_clone ... bench:   3,197,654 ns/iter (+/- 98,527)
test bench::bench_match_clone  ... bench:   3,193,360 ns/iter (+/- 74,968)
test bench::bench_new_clone    ... bench:   3,192,459 ns/iter (+/- 76,398)
```