### PR TITLE
feat: Add `SmolStr::from_static`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@
 
 A `SmolStr` is a string type that has the following properties:
 
-* `size_of::<SmolStr>() == 24 (therefore == size_of::<String>() on 64 bit platforms)
+* `size_of::<SmolStr>() == 24` (therefore `== size_of::<String>()` on 64 bit platforms)
 * `Clone` is `O(1)`
 * Strings are stack-allocated if they are:
     * Up to 23 bytes long
     * Longer than 23 bytes, but substrings of `WS` (see `src/lib.rs`). Such strings consist
     solely of consecutive newlines, followed by consecutive spaces
 * If a string does not satisfy the aforementioned conditions, it is heap-allocated
+* Additionally, a `SmolStr` can be explicitly created from a `&'static str` without allocation
 
 Unlike `String`, however, `SmolStr` is immutable. The primary use case for
 `SmolStr` is a good enough default storage for tokens of typical programming


### PR DESCRIPTION
Allows creating `SmolStr`s longer than 23 bytes in constant contexts.

This is done by replacing the `Repr::Substring` variant by a more general `Repr::Static(&'static str)` variant, and borrowing from ̀`WS` directly instead of storing two `usize`s.

As a bonus, it also simplifies the `as_str` implementation, hopefully saving an extra branch.