### PR TITLE
Fix a very small typography bug in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A `SmolStr` is a string type that has the following properties:
 
-* `size_of::<SmolStr>() == 24 (therefore == size_of::<String>() on 64 bit platforms)
+* `size_of::<SmolStr>() == 24` (therefore `== size_of::<String>()` on 64 bit platforms)
 * `Clone` is `O(1)`
 * Strings are stack-allocated if they are:
     * Up to 23 bytes long


### PR DESCRIPTION
I noticed that the README looked a bit odd:

> `size_of::() == 24 (therefore == size_of::() on 64 bit platforms)

This patch at least means that the turbofish parameters are legible, and is hopefully closer to what was originally intended.