### PR TITLE
Clippy + Cleanup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,8 @@ impl SmolStr {
     /// Panics if `text.len() > 23`.
     #[inline]
     pub const fn new_inline(text: &str) -> SmolStr {
+        assert!(text.len() <= INLINE_CAP); // avoids checks in loop
+
         let mut buf = [0; INLINE_CAP];
         let mut i = 0;
         while i < text.len() {


### PR DESCRIPTION
Just a few changes recommended by Clippy and minor performance tweaks. The assert in `new_inline` helps codegen tremendously. 