### PR TITLE
Add StrExt::replace_smolstr, replacen_smolstr

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -312,4 +312,18 @@ mod test_str_ext {
         assert_eq!(uppercase, "AßΔC");
         assert!(!uppercase.is_heap_allocated());
     }
+
+    #[test]
+    fn replace() {
+        let result = "foo_bar_baz".replace_smolstr("ba", "do");
+        assert_eq!(result, "foo_dor_doz");
+        assert!(!result.is_heap_allocated());
+    }
+
+    #[test]
+    fn replacen() {
+        let result = "foo_bar_baz".replacen_smolstr("ba", "do", 1);
+        assert_eq!(result, "foo_dor_baz");
+        assert!(!result.is_heap_allocated());
+    }
 }


### PR DESCRIPTION
Add `StrExt::replace_smolstr`, `StrExt::replacen_smolstr`.

This is useful to avoid allocation on small strings, e.g:
```rust
let result = "foo-bar_baz".replace_smolstr("-", "_");
assert_eq!(result, "foo_bar_baz");
assert!(!result.is_heap_allocated());
```

Impl adapted from [std `str::replacen`](https://doc.rust-lang.org/src/alloc/str.rs.html#309).

One undesirable difference from std is `from` uses `Pattern` in `str::replace` but this is not stable and can't be used here. However, I still think this version with `from: &str` is quite useful & worth having. Also if/when `Pattern` stabilizes we can start using it as a non-breaking change, since `&str` will implement it.

Note: While not needed for this PR this kind of usage is an example of why https://github.com/rust-analyzer/smol_str/issues/70 would be useful for external use.