### PR TITLE
Add support for borsh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ all-features = true
 
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false }
+borsh = { version = "1.4.0", optional = true, default-features = false }
 arbitrary = { version = "1.3", optional = true }
 
 [dev-dependencies]
@@ -22,4 +23,4 @@ serde = { version = "1.0", features = ["derive"] }
 
 [features]
 default = ["std"]
-std = ["serde?/std"]
+std = ["serde?/std", "borsh?/std"]

--- a/src/borsh.rs
+++ b/src/borsh.rs
@@ -40,19 +40,3 @@ impl BorshDeserialize for SmolStr {
         }
     }
 }
-
-#[cfg(feature = "borsh/unstable__schema")]
-mod schema {
-    use alloc::collections::BTreeMap;
-    use borsh::schema::{Declaration, Definition};
-    use borsh::BorshSchema;
-    impl BorshSchema for SmolStr {
-        fn add_definitions_recursively(definitions: &mut BTreeMap<Declaration, Definition>) {
-            str::add_definitions_recursively(definitions)
-        }
-
-        fn declaration() -> Declaration {
-            str::declaration()
-        }
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -795,5 +795,7 @@ impl<'a> arbitrary::Arbitrary<'a> for SmolStr {
     }
 }
 
+#[cfg(feature = "borsh")]
+mod borsh;
 #[cfg(feature = "serde")]
 mod serde;


### PR DESCRIPTION
[Borsh](https://borsh.io/)  is a non serde compliant serialization format with wide usage (e.g. [13m downloads of the Rust crate for borsh](https://crates.io/crates/borsh)). This PR adds support for `SmolStr` to be used with borsh.