### PR TITLE
Document crate feature guards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,12 @@ repository = "https://github.com/rust-analyzer/smol_str"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 edition = "2018"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
+
 [dependencies]
-serde = { version = "1.0.136", optional = true, default_features = false }
+serde = { version = "1.0.136", optional = true, default-features = false }
 arbitrary = { version = "1.1.0", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 extern crate alloc;
 
 use alloc::{borrow::Cow, boxed::Box, string::String, sync::Arc};
@@ -21,7 +23,7 @@ use core::{
 ///     * Longer than 23 bytes, but substrings of `WS` (see below). Such strings consist
 ///     solely of consecutive newlines, followed by consecutive spaces
 /// * If a string does not satisfy the aforementioned conditions, it is heap-allocated
-/// * Additionally, a `SmolStr` can be explicitely created from a `&'static str` without allocation
+/// * Additionally, a `SmolStr` can be explicitly created from a `&'static str` without allocation
 ///
 /// Unlike `String`, however, `SmolStr` is immutable. The primary use case for
 /// `SmolStr` is a good enough default storage for tokens of typical programming


### PR DESCRIPTION
- Expose `Deserialize`, etc impls on docs.rs, with crate feature hints.
- Migrate `default_features` -> `default-features` due to warning.
- Correct a spelling error.

![2024-06-01_05 41 48-1f5b851a](https://github.com/rust-analyzer/smol_str/assets/3316789/3fc4011d-91ef-4c9f-8542-671e014d614f)
