### PR TITLE
Migrate CI to actions-rust-lang/setup-rust-toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,11 +27,9 @@ jobs:
         fetch-depth: 0
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: stable
-        profile: minimal
-        override: true
+        cache: false
 
     - run: rustc ./.github/ci.rs && ./ci
       env:


### PR DESCRIPTION
Just a suggeston. The actions-rs repos are deprecated. This action is mainained by myself and @jonasbb.