### PR TITLE
Publish 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smol_str"
-version = "0.3.0"
+version = "0.3.1"
 description = "small-string optimized string type with O(1) clone"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-analyzer/smol_str"


### PR DESCRIPTION
and yank `0.3.0`, forgot that `enum`s expose the implementation details 🙃 