### PR TITLE
Add 0.2.2 changelog & fix lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,4 @@
 ## 0.2.2 - 2024-05-14
 
 - Add `StrExt` trait providing `to_lowercase_smolstr`, `replace_smolstr` and similar
-- Add `PartialEq` optimisation for `ptr_eq`-able representations
+- Add `PartialEq` optimization for `ptr_eq`-able representations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@
 
 ## 0.3.0 - 2024-09-04
 
-- Removed deprecated `SmolStr::new_inline_from_ascii` function
-- Removed `SmolStr::to_string` in favor of `ToString::to_string`
-- Added `impl AsRef<[u8]> for SmolStr` impl
-- Added `impl AsRef<OsStr> for SmolStr` impl
-- Added `impl AsRef<Path> for SmolStr` impl
-- Added `SmolStrBuilder`
+- Remove deprecated `SmolStr::new_inline_from_ascii` function
+- Remove `SmolStr::to_string` in favor of `ToString::to_string`
+- Add `impl AsRef<[u8]> for SmolStr` impl
+- Add `impl AsRef<OsStr> for SmolStr` impl
+- Add `impl AsRef<Path> for SmolStr` impl
+- Add `SmolStrBuilder`
+
+## 0.2.2 - 2024-05-14
+
+- Add `StrExt` trait providing `to_lowercase_smolstr`, `replace_smolstr` and similar
+- Add `PartialEq` optimisation for `ptr_eq`-able representations

--- a/src/borsh.rs
+++ b/src/borsh.rs
@@ -22,7 +22,7 @@ impl BorshDeserialize for SmolStr {
                 Error::new(ErrorKind::InvalidData, msg)
             })?;
             Ok(SmolStr(Repr::Inline {
-                len: unsafe { transmute(len as u8) },
+                len: unsafe { transmute::<u8, crate::InlineSize>(len as u8) },
                 buf,
             }))
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use core::{
 /// * Strings are stack-allocated if they are:
 ///     * Up to 23 bytes long
 ///     * Longer than 23 bytes, but substrings of `WS` (see below). Such strings consist
-///     solely of consecutive newlines, followed by consecutive spaces
+///       solely of consecutive newlines, followed by consecutive spaces
 /// * If a string does not satisfy the aforementioned conditions, it is heap-allocated
 /// * Additionally, a `SmolStr` can be explicitly created from a `&'static str` without allocation
 ///


### PR DESCRIPTION
Thanks for kicking off the changelog file :tada: 

Added `0.2.2` to the changelog using the publish date. Also fixed a couple of clippy lints that popped up in my editor.

I changed the changelog to present tense, but I can remove that if you prefer the past tense.