### PR TITLE
Fix `SmoLStrBuilder::push` pushing null bytes on heap spill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.2 - 2024-10-23
+
+- Fix `SmolStrBuilder::push` incorrectly padding null bytes when spilling onto the heap on a
+  multibyte character push
+
 ## 0.3.1 - 2024-09-04
 
 - Fix `SmolStrBuilder` leaking implementation details

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smol_str"
-version = "0.3.1"
+version = "0.3.2"
 description = "small-string optimized string type with O(1) clone"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-analyzer/smol_str"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -763,7 +763,7 @@ impl SmolStrBuilder {
                     let mut heap = String::with_capacity(new_len);
                     // copy existing inline bytes over to the heap
                     // SAFETY: inline data is guaranteed to be valid utf8 for `old_len` bytes
-                    unsafe { heap.as_mut_vec().extend_from_slice(buf) };
+                    unsafe { heap.as_mut_vec().extend_from_slice(&buf[..*len]) };
                     heap.push(c);
                     self.0 = SmolStrBuilderRepr::Heap(heap);
                 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -255,6 +255,7 @@ fn test_to_smolstr() {
         assert_eq!(a, smol_str::format_smolstr!("{}", a));
     }
 }
+
 #[test]
 fn test_builder_push_str() {
     //empty
@@ -290,6 +291,14 @@ fn test_builder_push_str() {
     let s = builder.finish();
     assert!(s.is_heap_allocated());
     assert_eq!("a".repeat(46), s);
+
+    // heap push on multibyte char
+    let mut builder = SmolStrBuilder::new();
+    builder.push_str("ohnonononononononono!");
+    builder.push('🤯');
+    let s = builder.finish();
+    assert!(s.is_heap_allocated());
+    assert_eq!("ohnonononononononono!🤯", s);
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/smol_str/issues/88