### PR TITLE
Add `portable-atomic` Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ all-features = true
 serde = { version = "1.0", optional = true, default-features = false }
 borsh = { version = "1.4.0", optional = true, default-features = false }
 arbitrary = { version = "1.3", optional = true }
+portable-atomic = { version = "1", default-features = false, optional = true }
+portable-atomic-util = { version = "0.2.4", features = [
+  "alloc",
+], optional = true }
 
 [dev-dependencies]
 proptest = "1.5"
@@ -24,3 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 [features]
 default = ["std"]
 std = ["serde?/std", "borsh?/std"]
+portable-atomic = [
+  "dep:portable-atomic",
+  "dep:portable-atomic-util",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 extern crate alloc;
 
-use alloc::{borrow::Cow, boxed::Box, string::String, sync::Arc};
+use alloc::{borrow::Cow, boxed::Box, string::String};
 use core::{
     borrow::Borrow,
     cmp::{self, Ordering},
@@ -11,6 +11,12 @@ use core::{
     fmt, hash, iter, mem, ops,
     str::FromStr,
 };
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic_util::Arc;
+
+#[cfg(not(feature = "portable-atomic"))]
+use alloc::sync::Arc;
 
 /// A `SmolStr` is a string type that has the following properties:
 ///


### PR DESCRIPTION
# Objective

- Fixes #90

## Description

Added `portable-atomic` feature, which brings in `portable-atomic` and `portable-atomic-util` as a compatibility shim for `Arc` support on atomically challenged platforms, such as `thumbv6m-none-eabi`.

## Testing
 - `cargo check --no-default-features --target thumbv6m-none-eabi --features portable-atomic,portable-atomic/fallback,portable-atomic/critical-section`

## Notes

This is my first attempt at contributing to this project. Please let me know if there's anything I can do to assist with reviewing this change!
