### PR TITLE
Optimise `to_ascii_lowercase_smolstr`, `to_ascii_uppercase_smolstr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased 
+
+- Optimise `StrExt::to_ascii_lowercase_smolstr`, `StrExt::to_ascii_uppercase_smolstr` 
+  ~2x speedup inline, ~4-22x for heap.
+
 ## 0.3.2 - 2024-10-23
 
 - Fix `SmolStrBuilder::push` incorrectly padding null bytes when spilling onto the heap on a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,12 +644,36 @@ impl StrExt for str {
 
     #[inline]
     fn to_ascii_lowercase_smolstr(&self) -> SmolStr {
-        from_char_iter(self.chars().map(|c| c.to_ascii_lowercase()))
+        let len = self.len();
+        if len <= INLINE_CAP {
+            let mut buf = [0u8; INLINE_CAP];
+            buf[..len].copy_from_slice(self.as_bytes());
+            buf[..len].make_ascii_lowercase();
+            SmolStr(Repr::Inline {
+                // SAFETY: `len` is in bounds
+                len: unsafe { InlineSize::transmute_from_u8(len as u8) },
+                buf,
+            })
+        } else {
+            self.to_ascii_lowercase().into()
+        }
     }
 
     #[inline]
     fn to_ascii_uppercase_smolstr(&self) -> SmolStr {
-        from_char_iter(self.chars().map(|c| c.to_ascii_uppercase()))
+        let len = self.len();
+        if len <= INLINE_CAP {
+            let mut buf = [0u8; INLINE_CAP];
+            buf[..len].copy_from_slice(self.as_bytes());
+            buf[..len].make_ascii_uppercase();
+            SmolStr(Repr::Inline {
+                // SAFETY: `len` is in bounds
+                len: unsafe { InlineSize::transmute_from_u8(len as u8) },
+                buf,
+            })
+        } else {
+            self.to_ascii_uppercase().into()
+        }
     }
 
     #[inline]


### PR DESCRIPTION
Optimisation opportunity highlighted by testing against `String` perf and using benchmarks in #96.

## PR bench
```
group                                  master                  faster-ascii-case
-----                                  ------                  -----------------
to_ascii_lowercase_smolstr len=12      2.06     13.5±0.01ns    1.00      6.6±0.01ns
to_ascii_lowercase_smolstr len=50      4.31    110.3±0.19ns    1.00     25.6±0.07ns
to_ascii_lowercase_smolstr len=1000    22.17  1396.8±2.63ns    1.00     63.0±0.01ns
```

The change provides a significant perf improvement on inline & heap reprs. Also faster than `String` for len=12 now :slightly_smiling_face: 