### PR TITLE
Use serde_core over serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 all-features = true
 
 [dependencies]
-serde = { version = "1.0", optional = true, default-features = false }
+serde_core = { version = "1.0.220", optional = true, default-features = false }
 borsh = { version = "1.4.0", optional = true, default-features = false }
 arbitrary = { version = "1.3", optional = true }
 
@@ -23,4 +23,5 @@ serde = { version = "1.0", features = ["derive"] }
 
 [features]
 default = ["std"]
-std = ["serde?/std", "borsh?/std"]
+std = ["serde_core?/std", "borsh?/std"]
+serde = ["dep:serde_core"]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -2,6 +2,7 @@ use alloc::{string::String, vec::Vec};
 use core::fmt;
 
 use serde::de::{Deserializer, Error, Unexpected, Visitor};
+use serde_core as serde;
 
 use crate::SmolStr;
 


### PR DESCRIPTION
This crate does not rely on the serde derive macros. It'd be better to depend on serde_core instead to allow this crate and its dependents to compile in parallel with proc-macro dependent crates.